### PR TITLE
replace js keyword native

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,11 +57,11 @@ const sortify = (value, replacer, space) => {
     // replacer, toJSON(), cyclic references and other stuff is better handled by native stringifier.
     // So we do JSON.stringify(sortKeys( JSON.parse(JSON.stringify()) )).
     // This approach is slightly slower but much safer than a manual stringification.
-    let native = jsonStringify(value, replacer, 0);
-    if (!native || native[0] !== '{' && native[0] !== '[') { // if value is not an Object or Array
-        return native;
+    let nativeJson = jsonStringify(value, replacer, 0);
+    if (!nativeJson || nativeJson[0] !== '{' && nativeJson[0] !== '[') { // if value is not an Object or Array
+        return nativeJson;
     }
-    let cleanObj = JSON.parse(native);
+    let cleanObj = JSON.parse(nativeJson);
     return jsonStringify(sortKeys(cleanObj), null, space);
 };
 


### PR DESCRIPTION
please change name of variable native to something else, as it is also a javascript keyword, and e.g. some minifiers fail on it.